### PR TITLE
fix gradle config to use ext minsdkversion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,7 +29,7 @@ android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   buildToolsVersion getExtOrDefault('buildToolsVersion')
   defaultConfig {
-    minSdkVersion 16
+    minSdkVersion getExtOrIntegerDefault('minSdkVersion')
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
     versionCode 1
     versionName "1.0"

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,3 +2,4 @@ SiftReactNative_kotlinVersion=1.3.50
 SiftReactNative_compileSdkVersion=28
 SiftReactNative_buildToolsVersion=28.0.3
 SiftReactNative_targetSdkVersion=28
+SiftReactNative_minSdkVersion=16


### PR DESCRIPTION
Currently we are having to patch the plugin because the gradle build config is hardcoding values rather than inheriting them from the parent project. I applied the standard safeExtGet code popular in most gradle configs to inherit the parent values with a fallback. Otherwise user's projects will error out due to the hardcoding and users must patch the plugin to keep building.