### PR TITLE
Automating the sift react native releases.

### DIFF
--- a/.github/workflows/react_native_release.yml
+++ b/.github/workflows/react_native_release.yml
@@ -1,0 +1,41 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+env:
+  GH_TOKEN: ${{ github.token }}
+
+jobs:
+  release:
+    name: Perform the Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test
+
+#  Release arent available, uncomment below lines when release is available
+#       - name: Release the package
+#         run: |
+#           npm run release -- --yes
+#           git push --follow-tags
+
+      - name: Check release on npm
+        run: npm show sift-react-native version
+
+      - name: Check release on GitHub
+        run: |
+          curl -s https://api.github.com/repos/SiftScience/sift-react-native/releases/latest | jq -r '.tag_name'


### PR DESCRIPTION
## Purpose: 
- https://sift.atlassian.net/browse/CI-13309

## Testing:

```
[Release/Perform the Release]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/2] user= workdir=
| npm WARN deprecated w3c-hr-time@1.0.2: Use your platform's native performance.now() and performance.timeOrigin.
| npm WARN deprecated urix@0.1.0: Please see https://github.com/lydell/urix#deprecated
| npm WARN deprecated source-map-url@0.4.1: See https://github.com/lydell/source-map-url#deprecated
| npm WARN deprecated source-map-resolve@0.5.3: See https://github.com/lydell/source-map-resolve#deprecated
| npm WARN deprecated resolve-url@0.2.1: https://github.com/lydell/resolve-url#deprecated
| npm WARN deprecated sane@4.1.0: some dependency vulnerabilities fixed, support for node < 10 dropped, and newer ECMAScript syntax/features added
| npm WARN deprecated uglify-es@3.3.9: support for ECMAScript is superseded by `uglify-js` as of v3.13.0
| npm WARN deprecated babel-eslint@10.1.0: babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.
| npm WARN deprecated @hapi/topo@3.1.6: This version has been deprecated and is no longer supported or maintained
| npm WARN deprecated @hapi/bourne@1.3.2: This version has been deprecated and is no longer supported or maintained
| npm WARN deprecated @hapi/address@2.1.4: Moved to 'npm install @sideway/address'
| npm WARN deprecated @hapi/hoek@8.5.1: This version has been deprecated and is no longer supported or maintained
| npm WARN deprecated @hapi/joi@15.1.1: Switch to 'npm install joi'
| npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
| npm WARN deprecated @react-native-community/bob@0.16.2: This package has been renamed to 'react-native-builder-bob'. Please use it instead.
| npm WARN deprecated core-js@2.6.12: core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.
| npm WARN deprecated react-native@0.62.2: Issues and pull requests filed against this version are not supported. See the React Native release support policy to learn more: https://github.com/reactwg/react-native-releases#releases-support-policy
| 
| > sift-react-native@0.1.9 prepare
| > bob build
| 
| ℹ Building target commonjs
| ℹ Cleaning up previous build at lib/commonjs
| ℹ Compiling 1 files in src with babel
| Browserslist: caniuse-lite is outdated. Please run:
|   npx update-browserslist-db@latest
|   Why you should do it regularly: https://github.com/browserslist/update-db#readme
| ✓ Wrote files to lib/commonjs
| ℹ Building target module
| ℹ Cleaning up previous build at lib/module
| ℹ Compiling 1 files in src with babel
| ✓ Wrote files to lib/module
| ℹ Building target typescript
| ℹ Cleaning up previous build at lib/typescript
| ℹ Generating type definitions with tsc
| ✓ Wrote definition files to lib/typescript
| 
| added 1751 packages, and audited 1752 packages in 17s
| 
| 141 packages are looking for funding
|   run `npm fund` for details
| 
| 48 vulnerabilities (16 moderate, 22 high, 10 critical)
| 
| To address issues that do not require attention, run:
|   npm audit fix
| 
| To address all issues (including breaking changes), run:
|   npm audit fix --force
| 
| Run `npm audit` for details.
[Release/Perform the Release]   ✅  Success - Main Install dependencies
[Release/Perform the Release] ⭐ Run Main Run tests
[Release/Perform the Release]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/3] user= workdir=
| 
| > sift-react-native@0.1.9 test
| > jest
| 
|  PASS  src/__tests__/index.test.tsx
|   ✎ todo write a test
| 
Test Suites: 1 passed, 1 total
| Tests:       1 todo, 1 total
| Snapshots:   0 total
| Time:        0.806 s
| Ran all test suites.
[Release/Perform the Release]   ✅  Success - Main Run tests
[Release/Perform the Release] ⭐ Run Main Check release on npm
[Release/Perform the Release]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/4] user= workdir=
| 0.1.9
[Release/Perform the Release]   ✅  Success - Main Check release on npm
[Release/Perform the Release] ⭐ Run Main Check release on GitHub
[Release/Perform the Release]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/5] user= workdir=
| v0.1.9
[Release/Perform the Release]   ✅  Success - Main Check release on GitHub
[Release/Perform the Release] ⭐ Run Post Set up Node.js
[Release/Perform the Release]   🐳  docker exec cmd=[node /var/run/act/actions/actions-setup-node@v2/dist/cache-save/index.js] user= workdir=
[Release/Perform the Release]   💬  ::debug::Caching for '' is not supported
[Release/Perform the Release]   ✅  Success - Post Set up Node.js
[Release/Perform the Release] 🏁  Job succeeded


```