### PR TITLE
Fix TypeScript typings path

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A React Native wrapper for Sift iOS and Android SDKs",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
-  "types": "lib/typescript/src/index.d.ts",
+  "types": "lib/typescript/index.d.ts",
   "react-native": "src/index",
   "source": "src/index",
   "files": [


### PR DESCRIPTION
## Purpose

Fixes TypeScript typings not working, since `types` field isn't pointing to correct file in final NPM package.

## Summary

Fixes `types` field in package.json to point to correct file.
![image](https://github.com/SiftScience/sift-react-native/assets/6276139/7b25e2ea-b403-480f-ac38-6bc8d462d9b1)

## Testing

## Checklist
- [x] The change was thoroughly tested manually
- [ ] The change was covered with unit tests
- [ ] The change was tested with the integration example
- [ ] The version refers to the latest stable version of sift-android
- [ ] The version refers to the latest stable version of sift-ios
- [ ] Necessary changes were made in the integration example (if applicable)
- [ ] New functionality is reflected in README (if applicable)
