### PR TITLE
API-7866: Fixed non-compatible kotlin versions in example app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+﻿# Change Log
+
+## [0.1.13] - 2024-09-03
+
+### Fixed
+- Fixed non-compatible kotlin versions in example application that resulted in a build error for android.

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -6,6 +6,7 @@ buildscript {
         minSdkVersion = 21
         compileSdkVersion = 31
         targetSdkVersion = 31
+        kotlinVersion = "1.6.0"
 
         if (System.properties['os.arch'] == "aarch64") {
             // For M1 Users we need to use the NDK 24 which added support for aarch64
@@ -23,6 +24,7 @@ buildscript {
         classpath("com.android.tools.build:gradle:7.2.1")
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath("de.undercouch:gradle-download-task:5.0.1")
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }


### PR DESCRIPTION
## Purpose
A fix for non compatible kotlin versions that resulted in a build error for android.

## Summary
Duplicate of https://github.com/SiftScience/sift-react-native/pull/39

A fix for non compatible kotlin versions that resulted in a build error for android.
```
> Task :sift-react-native:compileDebugKotlin FAILED

FAILURE: Build completed with 2 failures.

1: Task failed with an exception.
-----------
* What went wrong:
Execution failed for task ':sift-react-native:compileDebugKotlin'.
> Compilation error. See log for more details

2: Task failed with an exception.
-----------
* What went wrong:
java.lang.StackOverflowError (no error message)

```

## Testing
- Tested running android on multiple machines with appropriate SDK and NDK configurations
- Ran tests and iOS versions which all passed

## Checklist
- [ x] The change was thoroughly tested manually
- [ x] The change was covered with unit tests
- [ x] The change was tested with the integration example
- [ x] The version refers to the latest stable version of sift-android
- [ x] The version refers to the latest stable version of sift-ios
- [ x] Necessary changes were made in the integration example (if applicable)
- [ x] New functionality is reflected in README (if applicable)
